### PR TITLE
fix: keystroke viz security — implement filter modes, safe default (#62)

### DIFF
--- a/followcursor/app/keystroke_renderer.py
+++ b/followcursor/app/keystroke_renderer.py
@@ -107,6 +107,7 @@ def _group_keystrokes(
     key_events: List[KeyEvent],
     timestamp_ms: float,
     display_duration_ms: int,
+    filter_mode: str = "shortcuts-only",
 ) -> List[Tuple[str, float, float]]:
     """Group recent keystrokes into display strings.
     
@@ -117,12 +118,24 @@ def _group_keystrokes(
         key_events: All recorded key events
         timestamp_ms: Current playback time
         display_duration_ms: How long keystrokes remain visible
+        filter_mode: "all", "modifiers-only", or "shortcuts-only"
         
     Returns:
         List of (display_text, timestamp, age) tuples for visible keystrokes
     """
     if not key_events:
         return []
+    
+    # Modifier key VK codes: Ctrl, Alt, Win (but not Shift alone)
+    MODIFIER_VKS = frozenset((
+        0x11,         # Ctrl
+        0x12,         # Alt
+        0xA2, 0xA3,   # LCtrl, RCtrl
+        0xA4, 0xA5,   # LAlt, RAlt
+        0x5B, 0x5C,   # LWin, RWin
+    ))
+    
+    SHIFT_VKS = frozenset((0x10, 0xA0, 0xA1))  # Shift, LShift, RShift
     
     visible = []
     for event in key_events:
@@ -133,9 +146,23 @@ def _group_keystrokes(
         # Skip events without vk_code
         if not hasattr(event, 'vk_code') or event.vk_code is None:
             continue
-            
-        key_name = _format_key_event(event.vk_code)
-        visible.append((key_name, event.timestamp, age))
+        
+        vk_code = event.vk_code
+        key_name = _format_key_event(vk_code)
+        
+        # Apply filter based on mode
+        if filter_mode == "modifiers-only":
+            # Only show keystrokes that include Ctrl, Alt, or Win modifiers
+            # Single character presses are skipped
+            if vk_code not in MODIFIER_VKS:
+                continue
+        elif filter_mode == "shortcuts-only":
+            # Only show modifier keys (Ctrl/Alt/Win) - character keys will be
+            # filtered out later when we check if group has a modifier
+            pass  # Will be filtered in grouping logic
+        # else: "all" mode - show everything
+        
+        visible.append((key_name, event.timestamp, age, vk_code))
     
     # Group keystrokes that are close together (within 100ms)
     if not visible:
@@ -143,25 +170,65 @@ def _group_keystrokes(
     
     grouped = []
     current_group = [visible[0][0]]
+    current_vks = [visible[0][3]]
     group_start = visible[0][1]
     
     for i in range(1, len(visible)):
-        key_name, ts, _ = visible[i]
+        key_name, ts, _, vk_code = visible[i]
         if ts - visible[i-1][1] < 100:  # 100ms window for grouping
             current_group.append(key_name)
+            current_vks.append(vk_code)
         else:
-            # Finalize current group
-            group_age = timestamp_ms - group_start
-            grouped.append(("+".join(current_group), group_start, group_age))
+            # Finalize current group - apply filter
+            if _should_show_group(current_vks, filter_mode, MODIFIER_VKS, SHIFT_VKS):
+                group_age = timestamp_ms - group_start
+                grouped.append(("+".join(current_group), group_start, group_age))
             current_group = [key_name]
+            current_vks = [vk_code]
             group_start = ts
     
     # Don't forget the last group
-    if current_group:
+    if current_group and _should_show_group(current_vks, filter_mode, MODIFIER_VKS, SHIFT_VKS):
         group_age = timestamp_ms - group_start
         grouped.append(("+".join(current_group), group_start, group_age))
     
     return grouped
+
+
+def _should_show_group(
+    vk_codes: List[int],
+    filter_mode: str,
+    modifier_vks: frozenset,
+    shift_vks: frozenset,
+) -> bool:
+    """Determine if a keystroke group should be shown based on filter mode.
+    
+    Args:
+        vk_codes: List of VK codes in this group
+        filter_mode: "all", "modifiers-only", or "shortcuts-only"
+        modifier_vks: Set of modifier VK codes (Ctrl, Alt, Win)
+        shift_vks: Set of Shift VK codes
+        
+    Returns:
+        True if the group should be displayed
+    """
+    if filter_mode == "all":
+        return True
+    
+    # For modifiers-only and shortcuts-only modes:
+    # Only show if group contains at least one Ctrl/Alt/Win modifier
+    has_modifier = any(vk in modifier_vks for vk in vk_codes)
+    
+    if filter_mode == "modifiers-only":
+        # Only show if it has a Ctrl/Alt/Win modifier
+        return has_modifier
+    
+    if filter_mode == "shortcuts-only":
+        # Only show if it has a Ctrl/Alt/Win modifier
+        # Single Shift+letter is NOT considered a shortcut
+        return has_modifier
+    
+    return True
 
 
 def _compute_fade_alpha(age_ms: float, display_duration_ms: int) -> float:
@@ -215,7 +282,9 @@ def draw_keystrokes_qpainter(
     if not config.enabled or not key_events:
         return
     
-    grouped = _group_keystrokes(key_events, timestamp_ms, config.display_duration_ms)
+    grouped = _group_keystrokes(
+        key_events, timestamp_ms, config.display_duration_ms, config.filter_mode
+    )
     if not grouped:
         return
     
@@ -322,7 +391,9 @@ def draw_keystrokes_cv(
     if not config.enabled or not key_events:
         return
     
-    grouped = _group_keystrokes(key_events, timestamp_ms, config.display_duration_ms)
+    grouped = _group_keystrokes(
+        key_events, timestamp_ms, config.display_duration_ms, config.filter_mode
+    )
     if not grouped:
         return
     

--- a/followcursor/app/models.py
+++ b/followcursor/app/models.py
@@ -464,7 +464,7 @@ class KeystrokeOverlayConfig:
     position: str = "bottom-center"  # "bottom-center", "bottom-left", "near-cursor"
     style: str = "floating-badge"    # "floating-badge", "minimal-text", "key-cap"
     display_duration_ms: int = 1500  # how long keystrokes remain visible
-    filter_mode: str = "all"         # "all", "modifiers-only", "shortcuts-only"
+    filter_mode: str = "shortcuts-only"  # "all", "modifiers-only", "shortcuts-only"
     font_size: int = 18
     opacity: float = 0.85            # 0.0 - 1.0
 
@@ -488,7 +488,7 @@ class KeystrokeOverlayConfig:
             position=d.get("position", "bottom-center"),
             style=d.get("style", "floating-badge"),
             display_duration_ms=d.get("displayDurationMs", 1500),
-            filter_mode=d.get("filterMode", "all"),
+            filter_mode=d.get("filterMode", "shortcuts-only"),
             font_size=d.get("fontSize", 18),
             opacity=d.get("opacity", 0.85),
         )

--- a/followcursor/app/widgets/editor_panel.py
+++ b/followcursor/app/widgets/editor_panel.py
@@ -412,11 +412,10 @@ class EditorPanel(QWidget):
         self._keystroke_filter_combo.addItem("All Keys", "all")
         self._keystroke_filter_combo.addItem("Modifiers Only", "modifiers-only")
         self._keystroke_filter_combo.addItem("Shortcuts Only", "shortcuts-only")
-        self._keystroke_filter_combo.setCurrentIndex(0)
+        self._keystroke_filter_combo.setCurrentIndex(2)  # Default to "Shortcuts Only"
         self._keystroke_filter_combo.setToolTip(
-            "All Keys = show every keystroke\n"
-            "Modifiers Only = only Ctrl, Alt, Shift combos\n"
-            "Shortcuts Only = only key combinations (Ctrl+X, Alt+Tab, etc.)"
+            "Only shows keyboard shortcuts (Ctrl+X, Alt+Tab, etc.)\n"
+            "Safer for tutorials with password entry"
         )
         self._keystroke_filter_combo.currentIndexChanged.connect(self._on_keystroke_config_changed)
         filter_row.addWidget(self._keystroke_filter_combo, 1)
@@ -1208,6 +1207,22 @@ class EditorPanel(QWidget):
     def _on_keystroke_config_changed(self) -> None:
         """Handle keystroke overlay configuration changes."""
         config = self.get_keystroke_config()
+        
+        # Update tooltip to warn about "All Keys" mode
+        if config.filter_mode == "all":
+            self._keystroke_filter_combo.setToolTip(
+                "⚠️ All keystrokes will be visible, including passwords and sensitive input"
+            )
+        elif config.filter_mode == "modifiers-only":
+            self._keystroke_filter_combo.setToolTip(
+                "Only shows keys with Ctrl, Alt, or Win modifiers"
+            )
+        else:  # shortcuts-only
+            self._keystroke_filter_combo.setToolTip(
+                "Only shows keyboard shortcuts (Ctrl+X, Alt+Tab, etc.)\n"
+                "Safer for tutorials with password entry"
+            )
+        
         self.keystroke_config_changed.emit(config)
         logger.info(
             "Keystroke config changed: position=%s, style=%s, filter=%s",


### PR DESCRIPTION
Fixes #62

Security fix: keystroke visualization filter modes were defined but not implemented. All keystrokes (including passwords) were displayed regardless of the filter setting.

## Changes

### 1. Implemented filter_mode in keystroke_renderer.py
- Added filtering logic in \_group_keystrokes()\ function
- Created \_should_show_group()\ helper to filter keystroke groups based on mode
- **All Keys** — shows every keystroke (user explicitly chose this)
- **Modifiers Only** — only shows keys with Ctrl, Alt, or Win modifiers
- **Shortcuts Only** — only shows keyboard shortcuts (Ctrl+X, Alt+Tab, etc.), single character presses are filtered out

### 2. Changed default filter_mode from 'all' to 'shortcuts-only'
- Updated default in \KeystrokeOverlayConfig\ dataclass
- Updated \rom_dict()\ method to use safe default for backward compatibility
- Updated UI combo box default selection to match

### 3. Added security warning in editor_panel.py
- Dynamic tooltip updates when filter mode changes
- When 'All Keys' is selected: shows ⚠️ warning about passwords and sensitive input
- When 'Modifiers Only' is selected: explains what will be shown
- When 'Shortcuts Only' is selected: explains safer behavior for tutorials

## Testing
✅ All 347 tests passed

## Security Impact
Before: All keystrokes visible by default, including passwords
After: Only keyboard shortcuts visible by default, with clear warnings when choosing 'All Keys'