### PR TITLE
docs: clarify squad history file exception to PR scope rule

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -91,6 +91,13 @@ followcursor/                    ← repo root
 
 All **features, bug fixes, and significant changes** must be developed on a dedicated branch (e.g. `fix/encoder-fallback`, `feat/gif-palette`). Create the branch before making changes, run the **Run Tests** task to verify, then merge back to `main` only after tests pass. Trivial documentation-only or comment-only edits may go directly on `main`.
 
+### PR Scope
+
+**Keep squad state changes separate from code changes** — except for `.squad/agents/*/history.md` files:
+
+- **Allowed together:** `.squad/agents/*/history.md` may be committed in the same PR as code changes, because history files document the agent's understanding of the code it worked on and are contextual to the change being reviewed.
+- **Must be separate:** `decisions.md`, `orchestration-log/`, `log/`, `ceremonies.md`, `team.md`, `routing.md`, and any other squad orchestration/state files must be committed in their own dedicated commits, never bundled with code, documentation, or config changes.
+
 ### Parallel Work & Merge Conflicts
 
 When multiple issues are being worked on simultaneously (e.g. by Copilot coding agent), **batch related issues** to avoid merge conflicts:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -96,7 +96,7 @@ All **features, bug fixes, and significant changes** must be developed on a dedi
 **Keep squad state changes separate from code changes** — except for `.squad/agents/*/history.md` files:
 
 - **Allowed together:** `.squad/agents/*/history.md` may be committed in the same PR as code changes, because history files document the agent's understanding of the code it worked on and are contextual to the change being reviewed.
-- **Must be separate:** `decisions.md`, `orchestration-log/`, `log/`, `ceremonies.md`, `team.md`, `routing.md`, and any other squad orchestration/state files must be committed in their own dedicated commits, never bundled with code, documentation, or config changes.
+- **Must be separate:** `decisions.md`, `orchestration-log/`, `log/`, `ceremonies.md`, `team.md`, `routing.md`, and any other squad orchestration/state files must be kept in separate PRs and in their own dedicated commits, never bundled with code, documentation, or config changes.
 
 ### Parallel Work & Merge Conflicts
 

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -477,6 +477,10 @@ Ralph should always trigger a release at the end of milestone work — defined a
 
 ### Directive
 
-Never mix `.squad/` state/history changes with feature or code changes in the same commit or PR. Squad-internal file updates (history.md, decisions.md, orchestration-log/, log/) must be committed separately from any code, documentation, or config changes.
+Never mix `.squad/` state changes with feature or code changes in the same commit or PR — **except** for `.squad/agents/*/history.md` files.
 
-**Rationale:** User request — mixing squad state with feature commits trips up reviewers who can't distinguish squad bookkeeping from real change content. Keeps squad bookkeeping separate and transparent.
+**Exception — agent history files:** `.squad/agents/*/history.md` documents an agent's understanding of the code it worked on. These files are contextually tied to the code changes they accompany and may travel in the same commit or PR as the code they describe.
+
+**Must always be separate:** `decisions.md`, `orchestration-log/`, `log/`, `ceremonies.md`, `team.md`, `routing.md`, and any other squad orchestration/state files must be committed separately from code, documentation, or config changes.
+
+**Rationale:** User request — mixing squad state with feature commits trips up reviewers who can't distinguish squad bookkeeping from real change content. History files are the exception because they are a direct artifact of the code work being reviewed.


### PR DESCRIPTION
Updates the PR scope convention to clarify that `.squad/agents/*/history.md` files **are allowed** to travel with code changes in the same commit/PR.

**What changed:**
- `.squad/decisions.md` — amends the Squad State Separation directive with an explicit exception for agent history files, and lists what must still be separate
- `.github/copilot-instructions.md` — adds a new "PR Scope" subsection under the Branching section documenting the rule and the exception

**Why:**
Agent history files document the agent's understanding of the code it worked on — they are contextual artifacts of the code change, not squad orchestration state. The original directive was aimed at decisions, logs, and orchestration files that confuse code reviewers. History files don't have that problem.

No code changes. No workflow added or removed (`check-pr-scope` does not exist in this repo).