### PR TITLE
fix: UI polish — fonts, dropdowns, keystrokes, thumbnails, palette, annotations

### DIFF
--- a/followcursor/app/keystroke_renderer.py
+++ b/followcursor/app/keystroke_renderer.py
@@ -368,48 +368,72 @@ def draw_keystrokes_qpainter(
         return
 
     gap = 8
-    total_w = sum(b[3] for b in badges) + gap * (len(badges) - 1)
-    max_badge_h = max(b[4] for b in badges)
+    # Available width for wrapping — use the screen width if available, else widget
+    avail_w = screen_rect_w if screen_rect_w > 0 else float(painter.device().width())
 
-    # Compute starting x so the row is centered or left-aligned
-    if config.position == "bottom-center":
-        row_start_x = base_x - total_w / 2
-    else:
-        row_start_x = base_x
+    # Lay out badges into rows, wrapping when a row would exceed available width
+    rows: list[list] = []
+    current_row: list = []
+    current_row_w = 0.0
+    for badge in badges:
+        badge_w = badge[3]
+        needed = badge_w if not current_row else gap + badge_w
+        if current_row and current_row_w + needed > avail_w:
+            rows.append(current_row)
+            current_row = [badge]
+            current_row_w = badge_w
+        else:
+            current_row.append(badge)
+            current_row_w += needed
+    if current_row:
+        rows.append(current_row)
 
-    x_offset = 0.0
-    for text, alpha, text_rect, badge_w, badge_h, padding_x, padding_y in badges:
-        badge_x = row_start_x + x_offset
-        badge_y = base_y - max_badge_h
-        
-        # Draw badge background
-        bg_alpha = int(255 * alpha * config.opacity)
-        font = QFont("Segoe UI", config.font_size, QFont.Weight.Medium)
-        painter.setFont(font)
-        painter.setPen(Qt.PenStyle.NoPen)
-        painter.setBrush(QBrush(QColor(*KEYSTROKE_BG_COLOR, bg_alpha)))
-        
-        if config.style == "floating-badge":
-            badge_rect = QRectF(badge_x, badge_y, badge_w, badge_h)
-            painter.drawRoundedRect(badge_rect, 8, 8)
-        elif config.style == "key-cap":
-            badge_rect = QRectF(badge_x, badge_y, badge_w, badge_h)
-            painter.drawRoundedRect(badge_rect, 4, 4)
-            highlight_rect = QRectF(badge_x + 2, badge_y + 2, badge_w - 4, badge_h / 2)
-            painter.setBrush(QBrush(QColor(255, 255, 255, int(30 * alpha))))
-            painter.drawRoundedRect(highlight_rect, 2, 2)
-        else:  # minimal-text
-            badge_rect = QRectF(badge_x, badge_y, badge_w, badge_h)
-            painter.drawRoundedRect(badge_rect, 4, 4)
-        
-        # Draw text
-        text_alpha = int(255 * alpha)
-        painter.setPen(QPen(QColor(*KEYSTROKE_TEXT_COLOR, text_alpha)))
-        text_x = badge_x + padding_x
-        text_y = badge_y + padding_y + text_rect.height()
-        painter.drawText(QPointF(text_x, text_y), text)
-        
-        x_offset += badge_w + gap
+    # Draw rows bottom-up
+    y_row_offset = 0.0
+    for row in reversed(rows):
+        row_w = sum(b[3] for b in row) + gap * (len(row) - 1)
+        row_max_h = max(b[4] for b in row)
+
+        if config.position == "bottom-center":
+            row_start_x = base_x - row_w / 2
+        else:
+            row_start_x = base_x
+
+        x_offset = 0.0
+        for text, alpha, text_rect, badge_w, badge_h, padding_x, padding_y in row:
+            badge_x = row_start_x + x_offset
+            badge_y = base_y - y_row_offset - row_max_h
+
+            # Draw badge background
+            bg_alpha = int(255 * alpha * config.opacity)
+            font = QFont("Segoe UI", config.font_size, QFont.Weight.Medium)
+            painter.setFont(font)
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.setBrush(QBrush(QColor(*KEYSTROKE_BG_COLOR, bg_alpha)))
+
+            if config.style == "floating-badge":
+                badge_rect = QRectF(badge_x, badge_y, badge_w, badge_h)
+                painter.drawRoundedRect(badge_rect, 8, 8)
+            elif config.style == "key-cap":
+                badge_rect = QRectF(badge_x, badge_y, badge_w, badge_h)
+                painter.drawRoundedRect(badge_rect, 4, 4)
+                highlight_rect = QRectF(badge_x + 2, badge_y + 2, badge_w - 4, badge_h / 2)
+                painter.setBrush(QBrush(QColor(255, 255, 255, int(30 * alpha))))
+                painter.drawRoundedRect(highlight_rect, 2, 2)
+            else:  # minimal-text
+                badge_rect = QRectF(badge_x, badge_y, badge_w, badge_h)
+                painter.drawRoundedRect(badge_rect, 4, 4)
+
+            # Draw text
+            text_alpha = int(255 * alpha)
+            painter.setPen(QPen(QColor(*KEYSTROKE_TEXT_COLOR, text_alpha)))
+            text_x = badge_x + padding_x
+            text_y = badge_y + padding_y + text_rect.height()
+            painter.drawText(QPointF(text_x, text_y), text)
+
+            x_offset += badge_w + gap
+
+        y_row_offset += row_max_h + gap
 
 
 # ── OpenCV/numpy-based keystroke rendering (for export) ────────────
@@ -498,88 +522,110 @@ def draw_keystrokes_cv(
         return
 
     gap = 12
-    total_w = sum(b[5] for b in badges) + gap * (len(badges) - 1)
-    max_badge_h = max(b[6] for b in badges)
+    avail_w = fw - 20  # 10px margin each side
 
-    # Compute starting x so the row is centered or left-aligned
-    if config.position == "bottom-center":
-        row_start_x = base_x - total_w // 2
-    else:
-        row_start_x = base_x
+    # Lay out badges into rows, wrapping when a row would exceed frame width
+    rows: list[list] = []
+    current_row: list = []
+    current_row_w = 0
+    for badge in badges:
+        badge_w = badge[5]
+        needed = badge_w if not current_row else gap + badge_w
+        if current_row and current_row_w + needed > avail_w:
+            rows.append(current_row)
+            current_row = [badge]
+            current_row_w = badge_w
+        else:
+            current_row.append(badge)
+            current_row_w += needed
+    if current_row:
+        rows.append(current_row)
 
-    # Draw each badge horizontally using a single overlay copy
+    # Draw rows bottom-up using a single overlay copy
     overlay = None
-    x_offset = 0
-    for text, alpha, text_w, text_h, baseline, badge_w, badge_h, padding_x, padding_y in badges:
-        badge_x = row_start_x + x_offset
-        badge_y = base_y - max_badge_h
-        
-        # Ensure badge is within frame bounds
-        badge_x = max(10, min(badge_x, fw - badge_w - 10))
-        badge_y = max(10, min(badge_y, fh - badge_h - 10))
-        
-        if overlay is None:
-            overlay = frame_bgr.copy()
-        
-        # Draw badge background
-        if config.style == "floating-badge":
-            cv2.rectangle(
-                overlay,
-                (badge_x, badge_y),
-                (badge_x + badge_w, badge_y + badge_h),
-                KEYSTROKE_BG_COLOR_BGR,
-                -1,
-            )
-        elif config.style == "key-cap":
-            cv2.rectangle(
-                overlay,
-                (badge_x, badge_y),
-                (badge_x + badge_w, badge_y + badge_h),
-                KEYSTROKE_BG_COLOR_BGR,
-                -1,
-            )
-            highlight_h = badge_h // 3
-            cv2.rectangle(
-                overlay,
-                (badge_x + 3, badge_y + 3),
-                (badge_x + badge_w - 3, badge_y + highlight_h),
-                (100, 90, 110),
-                -1,
-            )
-        else:  # minimal-text
-            cv2.rectangle(
-                overlay,
-                (badge_x, badge_y),
-                (badge_x + badge_w, badge_y + badge_h),
-                KEYSTROKE_BG_COLOR_BGR,
-                -1,
-            )
-        
-        # Blend badge region with frame using alpha
-        blend_alpha = alpha * config.opacity
-        np.copyto(
-            frame_bgr[badge_y:badge_y + badge_h, badge_x:badge_x + badge_w],
-            cv2.addWeighted(
+    y_row_offset = 0
+    for row in reversed(rows):
+        row_w = sum(b[5] for b in row) + gap * (len(row) - 1)
+        row_max_h = max(b[6] for b in row)
+
+        if config.position == "bottom-center":
+            row_start_x = base_x - row_w // 2
+        else:
+            row_start_x = base_x
+
+        x_offset = 0
+        for text, alpha, text_w, text_h, baseline, badge_w, badge_h, padding_x, padding_y in row:
+            badge_x = row_start_x + x_offset
+            badge_y = base_y - y_row_offset - row_max_h
+
+            # Clamp within frame bounds
+            badge_x = max(10, min(badge_x, fw - badge_w - 10))
+            badge_y = max(10, min(badge_y, fh - badge_h - 10))
+
+            if overlay is None:
+                overlay = frame_bgr.copy()
+
+            # Draw badge background
+            if config.style == "floating-badge":
+                cv2.rectangle(
+                    overlay,
+                    (badge_x, badge_y),
+                    (badge_x + badge_w, badge_y + badge_h),
+                    KEYSTROKE_BG_COLOR_BGR,
+                    -1,
+                )
+            elif config.style == "key-cap":
+                cv2.rectangle(
+                    overlay,
+                    (badge_x, badge_y),
+                    (badge_x + badge_w, badge_y + badge_h),
+                    KEYSTROKE_BG_COLOR_BGR,
+                    -1,
+                )
+                highlight_h = badge_h // 3
+                cv2.rectangle(
+                    overlay,
+                    (badge_x + 3, badge_y + 3),
+                    (badge_x + badge_w - 3, badge_y + highlight_h),
+                    (100, 90, 110),
+                    -1,
+                )
+            else:  # minimal-text
+                cv2.rectangle(
+                    overlay,
+                    (badge_x, badge_y),
+                    (badge_x + badge_w, badge_y + badge_h),
+                    KEYSTROKE_BG_COLOR_BGR,
+                    -1,
+                )
+
+            # Blend badge region with frame using alpha
+            blend_alpha = alpha * config.opacity
+            np.copyto(
                 frame_bgr[badge_y:badge_y + badge_h, badge_x:badge_x + badge_w],
-                1 - blend_alpha,
-                overlay[badge_y:badge_y + badge_h, badge_x:badge_x + badge_w],
-                blend_alpha,
-                0,
+                cv2.addWeighted(
+                    frame_bgr[badge_y:badge_y + badge_h, badge_x:badge_x + badge_w],
+                    1 - blend_alpha,
+                    overlay[badge_y:badge_y + badge_h, badge_x:badge_x + badge_w],
+                    blend_alpha,
+                    0,
+                )
             )
-        )
-        
-        # Draw text
-        text_x = badge_x + padding_x
-        text_y = badge_y + padding_y + text_h
-        cv2.putText(
-            frame_bgr,
-            text,
-            (text_x, text_y),
-            font,
-            font_scale,
-            KEYSTROKE_TEXT_COLOR_BGR,
-            font_thickness,
-            cv2.LINE_AA,
-        )
-        
-        x_offset += badge_w + gap
+
+            # Draw text
+            text_x = badge_x + padding_x
+            text_y = badge_y + padding_y + text_h
+            cv2.putText(
+                frame_bgr,
+                text,
+                (text_x, text_y),
+                font,
+                font_scale,
+                KEYSTROKE_TEXT_COLOR_BGR,
+                font_thickness,
+                cv2.LINE_AA,
+            )
+
+            x_offset += badge_w + gap
+
+        y_row_offset += row_max_h + gap

--- a/followcursor/app/keystroke_renderer.py
+++ b/followcursor/app/keystroke_renderer.py
@@ -346,53 +346,59 @@ def draw_keystrokes_qpainter(
     
     painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
     
-    # Draw each visible keystroke group
-    y_offset = 0.0
+    # Draw each visible keystroke group — laid out horizontally
+    x_offset = 0.0
+    # Pre-measure total width for centering
+    badges = []
     for text, _, age in grouped:
         alpha = _compute_fade_alpha(age, config.display_duration_ms)
         if alpha < 0.01:
             continue
-        
-        # Set up font
         font = QFont("Segoe UI", config.font_size, QFont.Weight.Medium)
         painter.setFont(font)
-        
-        # Measure text
         fm = painter.fontMetrics()
         text_rect = fm.boundingRect(text)
-        
-        # Badge dimensions
         padding_x = 16
         padding_y = 8
         badge_w = text_rect.width() + padding_x * 2
         badge_h = text_rect.height() + padding_y * 2
-        
-        # Position badge
-        if config.position == "bottom-center":
-            badge_x = base_x - badge_w / 2
-        else:
-            badge_x = base_x
-        badge_y = base_y - y_offset - badge_h
+        badges.append((text, alpha, text_rect, badge_w, badge_h, padding_x, padding_y))
+
+    if not badges:
+        return
+
+    gap = 8
+    total_w = sum(b[3] for b in badges) + gap * (len(badges) - 1)
+    max_badge_h = max(b[4] for b in badges)
+
+    # Compute starting x so the row is centered or left-aligned
+    if config.position == "bottom-center":
+        row_start_x = base_x - total_w / 2
+    else:
+        row_start_x = base_x
+
+    x_offset = 0.0
+    for text, alpha, text_rect, badge_w, badge_h, padding_x, padding_y in badges:
+        badge_x = row_start_x + x_offset
+        badge_y = base_y - max_badge_h
         
         # Draw badge background
         bg_alpha = int(255 * alpha * config.opacity)
+        font = QFont("Segoe UI", config.font_size, QFont.Weight.Medium)
+        painter.setFont(font)
         painter.setPen(Qt.PenStyle.NoPen)
         painter.setBrush(QBrush(QColor(*KEYSTROKE_BG_COLOR, bg_alpha)))
         
         if config.style == "floating-badge":
-            # Rounded rectangle
             badge_rect = QRectF(badge_x, badge_y, badge_w, badge_h)
             painter.drawRoundedRect(badge_rect, 8, 8)
         elif config.style == "key-cap":
-            # Key-like appearance with slight 3D effect
             badge_rect = QRectF(badge_x, badge_y, badge_w, badge_h)
             painter.drawRoundedRect(badge_rect, 4, 4)
-            # Draw inner highlight
             highlight_rect = QRectF(badge_x + 2, badge_y + 2, badge_w - 4, badge_h / 2)
             painter.setBrush(QBrush(QColor(255, 255, 255, int(30 * alpha))))
             painter.drawRoundedRect(highlight_rect, 2, 2)
         else:  # minimal-text
-            # Just text with subtle background
             badge_rect = QRectF(badge_x, badge_y, badge_w, badge_h)
             painter.drawRoundedRect(badge_rect, 4, 4)
         
@@ -403,8 +409,7 @@ def draw_keystrokes_qpainter(
         text_y = badge_y + padding_y + text_rect.height()
         painter.drawText(QPointF(text_x, text_y), text)
         
-        # Stack vertically
-        y_offset += badge_h + 8
+        x_offset += badge_w + gap
 
 
 # ── OpenCV/numpy-based keystroke rendering (for export) ────────────
@@ -474,37 +479,45 @@ def draw_keystrokes_cv(
     font_scale = config.font_size / 18.0  # Base scale
     font_thickness = max(1, int(font_scale * 2))
     
-    # Draw each visible keystroke group using a single overlay copy
-    y_offset = 0
-    overlay = None  # lazily allocated once per frame
+    # Pre-measure all badges for horizontal layout
+    badges = []
     for text, _, age in grouped:
         alpha = _compute_fade_alpha(age, config.display_duration_ms)
         if alpha < 0.01:
             continue
-        
-        # Measure text
         (text_w, text_h), baseline = cv2.getTextSize(
             text, font, font_scale, font_thickness
         )
-        
-        # Badge dimensions
         padding_x = 24
         padding_y = 12
         badge_w = text_w + padding_x * 2
         badge_h = text_h + padding_y * 2 + baseline
-        
-        # Position badge
-        if config.position == "bottom-center":
-            badge_x = base_x - badge_w // 2
-        else:
-            badge_x = base_x
-        badge_y = base_y - y_offset - badge_h
+        badges.append((text, alpha, text_w, text_h, baseline, badge_w, badge_h, padding_x, padding_y))
+
+    if not badges:
+        return
+
+    gap = 12
+    total_w = sum(b[5] for b in badges) + gap * (len(badges) - 1)
+    max_badge_h = max(b[6] for b in badges)
+
+    # Compute starting x so the row is centered or left-aligned
+    if config.position == "bottom-center":
+        row_start_x = base_x - total_w // 2
+    else:
+        row_start_x = base_x
+
+    # Draw each badge horizontally using a single overlay copy
+    overlay = None
+    x_offset = 0
+    for text, alpha, text_w, text_h, baseline, badge_w, badge_h, padding_x, padding_y in badges:
+        badge_x = row_start_x + x_offset
+        badge_y = base_y - max_badge_h
         
         # Ensure badge is within frame bounds
         badge_x = max(10, min(badge_x, fw - badge_w - 10))
         badge_y = max(10, min(badge_y, fh - badge_h - 10))
         
-        # Allocate a single overlay copy for the entire frame
         if overlay is None:
             overlay = frame_bgr.copy()
         
@@ -525,7 +538,6 @@ def draw_keystrokes_cv(
                 KEYSTROKE_BG_COLOR_BGR,
                 -1,
             )
-            # Inner highlight
             highlight_h = badge_h // 3
             cv2.rectangle(
                 overlay,
@@ -570,5 +582,4 @@ def draw_keystrokes_cv(
             cv2.LINE_AA,
         )
         
-        # Stack vertically
-        y_offset += badge_h + 12
+        x_offset += badge_w + gap

--- a/followcursor/app/main_window.py
+++ b/followcursor/app/main_window.py
@@ -1124,7 +1124,7 @@ class MainWindow(QMainWindow):
         self._btn_change_source.setVisible(False)
 
         self._btn_record = QPushButton("  Record  (Ctrl+Shift+R)")
-        self._btn_record.setIcon(load_icon("record", variant="filled", color=T.DANGER))
+        self._btn_record.setIcon(load_icon("record", variant="filled", color="#ffffff"))
         self._btn_record.setObjectName("RecordBtn")
         self._btn_record.clicked.connect(self._start_recording)
         self._btn_record.setVisible(False)

--- a/followcursor/app/main_window.py
+++ b/followcursor/app/main_window.py
@@ -851,6 +851,7 @@ class MainWindow(QMainWindow):
         self._preview.pan_point_requested.connect(self._on_preview_pan_point)
         self._preview.centroid_picked.connect(self._on_centroid_picked)
         self._preview.centroid_dragged.connect(self._on_centroid_dragged)
+        self._preview.annotation_dragged.connect(self._on_annotation_dragged)
 
         # Keyframe whose centroid is being repositioned via preview click
         self._centroid_target_kf_id: str = ""
@@ -1816,6 +1817,37 @@ class MainWindow(QMainWindow):
         self._preview.set_annotations(self._annotations)
         self._mark_dirty()
         logger.info("Annotation updated: %s", annot_type)
+
+    def _on_annotation_dragged(self, annot_type: str, annot_id: str, new_x: float, new_y: float) -> None:
+        """Handle annotation dragged in the preview widget."""
+        if self._annotations is None:
+            return
+
+        if annot_type == "text" and self._annotations.texts:
+            for a in self._annotations.texts:
+                if a.id == annot_id:
+                    a.x = new_x
+                    a.y = new_y
+                    break
+        elif annot_type == "arrow" and self._annotations.arrows:
+            for a in self._annotations.arrows:
+                if a.id == annot_id:
+                    dx = new_x - a.x1
+                    dy = new_y - a.y1
+                    a.x1 = new_x
+                    a.y1 = new_y
+                    a.x2 = max(0.0, min(1.0, a.x2 + dx))
+                    a.y2 = max(0.0, min(1.0, a.y2 + dy))
+                    break
+        elif annot_type == "highlight" and self._annotations.highlights:
+            for a in self._annotations.highlights:
+                if a.id == annot_id:
+                    a.x = new_x
+                    a.y = new_y
+                    break
+
+        self._preview.set_annotations(self._annotations)
+        self._mark_dirty()
 
     def _on_auto_detect_chapters(self) -> None:
         """Handle auto-detect chapters request from editor panel."""

--- a/followcursor/app/main_window.py
+++ b/followcursor/app/main_window.py
@@ -1832,12 +1832,21 @@ class MainWindow(QMainWindow):
         elif annot_type == "arrow" and self._annotations.arrows:
             for a in self._annotations.arrows:
                 if a.id == annot_id:
-                    dx = new_x - a.x1
-                    dy = new_y - a.y1
-                    a.x1 = new_x
-                    a.y1 = new_y
-                    a.x2 = max(0.0, min(1.0, a.x2 + dx))
-                    a.y2 = max(0.0, min(1.0, a.y2 + dy))
+                    midpoint_x = (a.x1 + a.x2) / 2.0
+                    midpoint_y = (a.y1 + a.y2) / 2.0
+                    dx = new_x - midpoint_x
+                    dy = new_y - midpoint_y
+                    # Constrain so translated endpoints stay within [0, 1]
+                    min_dx = -min(a.x1, a.x2)
+                    max_dx = 1.0 - max(a.x1, a.x2)
+                    min_dy = -min(a.y1, a.y2)
+                    max_dy = 1.0 - max(a.y1, a.y2)
+                    dx = max(min_dx, min(max_dx, dx))
+                    dy = max(min_dy, min(max_dy, dy))
+                    a.x1 += dx
+                    a.y1 += dy
+                    a.x2 += dx
+                    a.y2 += dy
                     break
         elif annot_type == "highlight" and self._annotations.highlights:
             for a in self._annotations.highlights:

--- a/followcursor/app/theme.py
+++ b/followcursor/app/theme.py
@@ -195,22 +195,28 @@ QComboBox::down-arrow {{
 QComboBox QAbstractItemView {{
     background-color: {T.BG_LAYER_4};
     color: {T.FG_PRIMARY};
-    border: 1px solid {T.STROKE_1};
+    border: 1px solid {T.STROKE_2};
     border-radius: {T.RADIUS_MEDIUM}px;
     padding: {T.SPACE_XS}px;
+    outline: none;
     selection-background-color: {T.BG_SUBTLE_SELECTED};
     selection-color: {T.FG_PRIMARY};
 }}
 QComboBox QAbstractItemView::item {{
-    padding: {T.SPACE_6}px {T.SPACE_SM}px;
+    padding: {T.SPACE_SM}px {T.SPACE_MD}px;
     border-radius: {T.RADIUS_SMALL}px;
-    min-height: 32px;
+    min-height: 36px;
+    border: none;
+    outline: none;
 }}
 QComboBox QAbstractItemView::item:hover {{
     background-color: {T.BG_SUBTLE_HOVER};
 }}
 QComboBox QAbstractItemView::item:selected {{
-    background-color: {T.BG_SUBTLE_SELECTED};
+    background-color: {T.BRAND_TRANSLUCENT};
+    color: {T.FG_PRIMARY};
+    border: none;
+    outline: none;
 }}
 
 /* ══════════════════════════════════════════════════════════════
@@ -849,14 +855,14 @@ QPushButton#SaveBtn:disabled {{
 }}
 #TimeDisplay {{
     color: {T.FG_PRIMARY};
-    font-size: {T.FONT_SIZE_CAPTION_1}px;
+    font-size: {T.FONT_SIZE_BODY_1}px;
     font-weight: {T.FONT_WEIGHT_MEDIUM};
     background: transparent;
     font-family: {T.FONT_FAMILY_MONO};
 }}
 #TimeDisplayDim {{
     color: {T.FG_3};
-    font-size: {T.FONT_SIZE_CAPTION_1}px;
+    font-size: {T.FONT_SIZE_BODY_1}px;
     font-weight: {T.FONT_WEIGHT_MEDIUM};
     background: transparent;
     font-family: {T.FONT_FAMILY_MONO};

--- a/followcursor/app/tokens.py
+++ b/followcursor/app/tokens.py
@@ -183,14 +183,13 @@ FONT_LINE_HEIGHT_TITLE_1: int = 52
 FONT_SIZE_DISPLAY: int = 68
 FONT_LINE_HEIGHT_DISPLAY: int = 92
 
-# Legacy aliases for backward compatibility (preserve original values)
-# Keep these at their original sizes so existing QSS doesn't break
+# Legacy aliases — bumped to improve readability on modern displays
 # Use new Fluent 2 tokens (FONT_SIZE_CAPTION_1, FONT_SIZE_BODY_1, etc.) for new code
-FONT_SIZE_CAPTION: int = 11    # original value preserved
-FONT_SIZE_BODY: int = 13       # original value preserved
-FONT_SIZE_SUBTITLE: int = 15   # original value preserved
-FONT_SIZE_TITLE: int = 16      # original value preserved
-FONT_SIZE_HEADER: int = 20     # original value preserved
+FONT_SIZE_CAPTION: int = 12    # bumped from 11
+FONT_SIZE_BODY: int = 14       # bumped from 13
+FONT_SIZE_SUBTITLE: int = 16   # bumped from 15
+FONT_SIZE_TITLE: int = 18      # bumped from 16
+FONT_SIZE_HEADER: int = 22     # bumped from 20
 
 # ── Animation (Fluent 2 Motion Tokens) ────────────────────────────────
 # Based on https://fluent2.microsoft.design/motion

--- a/followcursor/app/widgets/editor_panel.py
+++ b/followcursor/app/widgets/editor_panel.py
@@ -854,11 +854,11 @@ class EditorPanel(QWidget):
 
         # Patterns get larger, fewer-per-row swatches so the pattern is visible
         if category == CAT_PATTERN:
-            size, cols = 32, 7
+            size, cols = 44, 4
         elif category == CAT_GRADIENT:
-            size, cols = 28, 8
+            size, cols = 36, 6
         else:
-            size, cols = 24, 9
+            size, cols = 28, 8
 
         for idx, preset in enumerate(presets):
             btn = QPushButton()

--- a/followcursor/app/widgets/preview_widget.py
+++ b/followcursor/app/widgets/preview_widget.py
@@ -21,7 +21,10 @@ from PySide6.QtCore import Qt, QTimer, Signal, QPointF, QRectF
 from PySide6.QtGui import QImage, QPainter, QColor, QFont, QPen
 from PySide6.QtWidgets import QWidget, QMenu
 
-from ..models import MousePosition, ClickEvent, ZoomKeyframe
+from ..models import (
+    MousePosition, ClickEvent, ZoomKeyframe,
+    TextAnnotation, ArrowAnnotation, HighlightBox, AnnotationCollection,
+)
 from ..zoom_engine import speed_at_time
 from ..icon_loader import load_icon
 from .. import tokens as T
@@ -44,6 +47,8 @@ class PreviewWidget(QWidget):
     centroid_picked = Signal(float, float)
     # Signal: (kf_id, pan_x, pan_y) — emitted while dragging a centroid marker
     centroid_dragged = Signal(str, float, float)
+    # Signal: (annotation_type, annotation_id, new_x, new_y) — emitted when annotation dragged
+    annotation_dragged = Signal(str, str, float, float)
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -89,6 +94,12 @@ class PreviewWidget(QWidget):
         # centroid drag state (overlay markers)
         self._centroid_drag_kf_id: str = ""  # keyframe being dragged
         self._centroid_drag_undo_pushed: bool = False
+
+        # annotation drag state
+        self._annot_drag_type: str = ""     # "text", "arrow", "highlight"
+        self._annot_drag_id: str = ""       # annotation id being dragged
+        self._annot_drag_offset_x: float = 0.0  # click offset from position
+        self._annot_drag_offset_y: float = 0.0
 
         # Enable mouse tracking for hover cursor changes
         self.setMouseTracking(True)
@@ -237,6 +248,17 @@ class PreviewWidget(QWidget):
                     self._centroid_drag_undo_pushed = False
                     self.setCursor(Qt.CursorShape.ClosedHandCursor)
                     return
+            # Check if click hits an annotation
+            hit = self._annotation_hit_test(
+                event.position().x(), event.position().y()
+            )
+            if hit:
+                self._annot_drag_type = hit[0]
+                self._annot_drag_id = hit[1]
+                self._annot_drag_offset_x = hit[2]
+                self._annot_drag_offset_y = hit[3]
+                self.setCursor(Qt.CursorShape.ClosedHandCursor)
+                return
         super().mousePressEvent(event)
 
     def mouseMoveEvent(self, event) -> None:  # type: ignore[override]
@@ -249,12 +271,33 @@ class PreviewWidget(QWidget):
                     self._centroid_drag_kf_id, pan_x, pan_y
                 )
             return
+        # Annotation drag in progress
+        if self._annot_drag_id:
+            pan_x, pan_y = self._click_to_pan(
+                event.position().x(), event.position().y()
+            )
+            if pan_x >= 0:
+                new_x = max(0.0, min(1.0, pan_x - self._annot_drag_offset_x))
+                new_y = max(0.0, min(1.0, pan_y - self._annot_drag_offset_y))
+                self.annotation_dragged.emit(
+                    self._annot_drag_type, self._annot_drag_id, new_x, new_y
+                )
+            return
         # Hover cursor: show open hand when over a centroid marker
         if self._debug_overlay and self._debug_keyframes:
             hit_id = self._centroid_hit_test(
                 event.position().x(), event.position().y()
             )
             if hit_id:
+                self.setCursor(Qt.CursorShape.OpenHandCursor)
+            elif not self._centroid_pick_mode:
+                self.unsetCursor()
+        # Hover cursor: show open hand when over a draggable annotation
+        elif self._annotations is not None:
+            hit = self._annotation_hit_test(
+                event.position().x(), event.position().y()
+            )
+            if hit:
                 self.setCursor(Qt.CursorShape.OpenHandCursor)
             elif not self._centroid_pick_mode:
                 self.unsetCursor()
@@ -267,6 +310,16 @@ class PreviewWidget(QWidget):
         ):
             self._centroid_drag_kf_id = ""
             self._centroid_drag_undo_pushed = False
+            self.unsetCursor()
+            return
+        if (
+            event.button() == Qt.MouseButton.LeftButton
+            and self._annot_drag_id
+        ):
+            self._annot_drag_type = ""
+            self._annot_drag_id = ""
+            self._annot_drag_offset_x = 0.0
+            self._annot_drag_offset_y = 0.0
             self.unsetCursor()
             return
         super().mouseReleaseEvent(event)
@@ -681,6 +734,89 @@ class PreviewWidget(QWidget):
         return ""
 
     # \u2500\u2500 painting \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+
+    def _annotation_hit_test(
+        self, wx: float, wy: float
+    ) -> tuple[str, str, float, float] | None:
+        """Check if widget position (wx, wy) hits a visible annotation.
+
+        Returns ``(type, id, offset_x, offset_y)`` where offset is the
+        normalized distance from the click to the annotation's anchor
+        position, or ``None`` if nothing was hit.
+
+        Check order: text (topmost) -> arrows -> highlights (bottommost).
+        """
+        if self._annotations is None:
+            return None
+
+        cx, cy, W, H, scr_x, scr_y, scr_w, scr_h = self._screen_geometry()
+        if W <= 0 or scr_w <= 0:
+            return None
+
+        # Normalized click position via _click_to_pan (handles zoom correction)
+        nx, ny = self._click_to_pan(wx, wy)
+        if nx < 0:
+            return None
+
+        t = self._current_time_ms
+        HIT_RADIUS_NORM = 10.0 / max(scr_w, 1)  # ~10px in normalized space
+
+        # Text annotations (front layer -- checked first)
+        if self._annotations.texts:
+            for text_ann in reversed(self._annotations.texts):
+                if not (text_ann.start_ms <= t <= text_ann.end_ms):
+                    continue
+                # Badge size approximation: ~80x30px in screen space
+                half_w = 40.0 / max(scr_w, 1)
+                half_h = 15.0 / max(scr_h, 1)
+                if (abs(nx - text_ann.x) <= half_w
+                        and abs(ny - text_ann.y) <= half_h):
+                    return ("text", text_ann.id,
+                            nx - text_ann.x, ny - text_ann.y)
+
+        # Arrow annotations (middle layer)
+        if self._annotations.arrows:
+            for arrow in reversed(self._annotations.arrows):
+                if not (arrow.start_ms <= t <= arrow.end_ms):
+                    continue
+                # Point-to-segment distance in normalized space
+                dist = self._point_to_segment_dist(
+                    nx, ny, arrow.x1, arrow.y1, arrow.x2, arrow.y2
+                )
+                if dist <= HIT_RADIUS_NORM:
+                    mid_x = (arrow.x1 + arrow.x2) / 2
+                    mid_y = (arrow.y1 + arrow.y2) / 2
+                    return ("arrow", arrow.id,
+                            nx - mid_x, ny - mid_y)
+
+        # Highlight annotations (back layer -- checked last)
+        if self._annotations.highlights:
+            for hl in reversed(self._annotations.highlights):
+                if not (hl.start_ms <= t <= hl.end_ms):
+                    continue
+                if (hl.x <= nx <= hl.x + hl.width
+                        and hl.y <= ny <= hl.y + hl.height):
+                    return ("highlight", hl.id,
+                            nx - hl.x, ny - hl.y)
+
+        return None
+
+    @staticmethod
+    def _point_to_segment_dist(
+        px: float, py: float,
+        x1: float, y1: float,
+        x2: float, y2: float,
+    ) -> float:
+        """Return the shortest distance from point (px, py) to segment (x1,y1)-(x2,y2)."""
+        dx = x2 - x1
+        dy = y2 - y1
+        len_sq = dx * dx + dy * dy
+        if len_sq < 1e-12:
+            return ((px - x1) ** 2 + (py - y1) ** 2) ** 0.5
+        t = max(0.0, min(1.0, ((px - x1) * dx + (py - y1) * dy) / len_sq))
+        proj_x = x1 + t * dx
+        proj_y = y1 + t * dy
+        return ((px - proj_x) ** 2 + (py - proj_y) ** 2) ** 0.5
 
     def paintEvent(self, event) -> None:  # type: ignore[override]
         from ..compositor import compose_scene, draw_empty_bg

--- a/followcursor/app/widgets/source_picker.py
+++ b/followcursor/app/widgets/source_picker.py
@@ -340,8 +340,8 @@ class SourcePickerDialog(QDialog):
     def _on_monitor_thumb(self, monitor_index: int, pixmap) -> None:
         card = self._card_by_monitor.get(monitor_index)
         if card and pixmap:
-            tw = card._thumb_label.width() or 400
-            th = card._thumb_label.height() or 200
+            tw = card._thumb_label.width() or 800
+            th = card._thumb_label.height() or 400
             card._thumb_label.setPixmap(
                 pixmap.scaled(tw, th,
                               Qt.AspectRatioMode.KeepAspectRatio,
@@ -351,8 +351,8 @@ class SourcePickerDialog(QDialog):
     def _on_window_thumb(self, hwnd: int, pixmap) -> None:
         card = self._card_by_hwnd.get(hwnd)
         if card and pixmap:
-            tw = card._thumb_label.width() or 400
-            th = card._thumb_label.height() or 200
+            tw = card._thumb_label.width() or 800
+            th = card._thumb_label.height() or 400
             card._thumb_label.setPixmap(
                 pixmap.scaled(tw, th,
                               Qt.AspectRatioMode.KeepAspectRatio,

--- a/followcursor/app/widgets/source_picker.py
+++ b/followcursor/app/widgets/source_picker.py
@@ -73,7 +73,7 @@ class _WindowThumbWorker(QThread):
         for win in self._windows:
             if self._cancelled:
                 return
-            thumb = capture_window_thumbnail(win["hwnd"])
+            thumb = capture_window_thumbnail(win["hwnd"], max_w=800, max_h=440)
             if thumb is not None:
                 h, w, c = thumb.shape
                 qimg = QImage(thumb.data, w, h, w * c, QImage.Format.Format_RGB888)
@@ -123,7 +123,7 @@ class _SourceCard(QFrame):
         )
         if thumb:
             self._thumb_label.setPixmap(
-                thumb.scaled(self._thumb_label.width() or 400, 200,
+                thumb.scaled(self._thumb_label.width() or 800, 400,
                              Qt.AspectRatioMode.KeepAspectRatio,
                              Qt.TransformationMode.SmoothTransformation)
             )


### PR DESCRIPTION
## Summary

Comprehensive UI polish addressing multiple user-reported issues from visual testing.

### Changes

#### Wave 1 — Theme & Quick Fixes
- **Increase font sizes** — Bump legacy font aliases (caption 11→12, body 13→14, subtitle 15→16, title 16→18, header 20→22). Increase TimeDisplay from 12px to 14px. (Closes #143)
- **Improve dropdown styling** — Softer border on popup, larger items (36px), brand-tinted selection highlight, remove harsh outline on selected item. (Closes #147)
- **Horizontal keystroke layout** — Change keystroke overlay from vertical stack to horizontal row in both QPainter (preview) and OpenCV (export) renderers. (Closes #150)
- **Higher-res window thumbnails** — Increase window capture resolution from 400×220 to 800×440 for sharper source picker previews. (Closes #149)

#### Wave 2 — Button & Palette Fixes
- **Record button icon** — Fix invisible icon (was red-on-red) → white icon on red background. (Closes #146)
- **Background palette layout** — Increase swatch sizes and adjust columns to prevent orphan swatches: patterns 32→44px (4 cols), gradients 28→36px (6 cols), solids 24→28px (8 cols). (Closes #145)

#### Wave 3 — Annotation Drag Support
- **Draggable annotations** — Add mouse event handling for dragging text, arrow, and highlight annotations in the preview widget. Includes hit-testing, offset-corrected movement, hover cursor feedback, and signal wiring. (Closes #148)

### Already Implemented (issues closed as-is)
- **#144** — Sidebar already uses Fluent SVG icons via `load_icon()` and `QToolButton`
- **#151** — Chapter markers already fully implemented with signal flow EditorPanel → MainWindow → Timeline

### Testing
All 412 tests pass.