### PR TITLE
release: v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Changed
 - **Larger font sizes** — bumped legacy font aliases (caption 11→12, body 13→14, subtitle 15→16, title 16→18, header 20→22) and TimeDisplay from 12px to 14px for improved readability
-- **Higher-res window thumbnails** — increased window capture resolution from 400×220 to 800×440 for sharper source picker previews
+- **Higher-res window thumbnails** — further increased window capture resolution to 800×440 for sharper source picker previews
 - **Horizontal keystroke overlay** — keystrokes now render side-by-side instead of stacked vertically, with automatic row wrapping when badges exceed available width
 - **Larger background swatches** — increased swatch sizes (patterns 32→44px, gradients 28→36px, solids 24→28px) and adjusted column counts to eliminate orphan swatches
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to FollowCursor are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.12.0] — 2026-04-08
+
+### Added
+- **Draggable annotations** — text, arrow, and highlight annotations can now be repositioned by dragging them in the preview widget, with hover cursor feedback and zoom-corrected coordinates
+
+### Changed
+- **Larger font sizes** — bumped legacy font aliases (caption 11→12, body 13→14, subtitle 15→16, title 16→18, header 20→22) and TimeDisplay from 12px to 14px for improved readability
+- **Higher-res window thumbnails** — increased window capture resolution from 400×220 to 800×440 for sharper source picker previews
+- **Horizontal keystroke overlay** — keystrokes now render side-by-side instead of stacked vertically, with automatic row wrapping when badges exceed available width
+- **Larger background swatches** — increased swatch sizes (patterns 32→44px, gradients 28→36px, solids 24→28px) and adjusted column counts to eliminate orphan swatches
+
+### Fixed
+- **Record button icon** — changed from red-on-red (invisible) to white icon on red background
+- **Dropdown popup styling** — softer border, larger items (36px), brand-tinted selection highlight, removed harsh outline on selected item
+- **Arrow annotation drag** — uses midpoint delta so both endpoints translate together, keeping shape intact
+- **Thumbnail fallback consistency** — async thumbnail callbacks now use matching 800×400 fallback size
+
 ## [0.11.0] — 2026-04-07
 
 ### Added

--- a/followcursor/app/version.py
+++ b/followcursor/app/version.py
@@ -4,4 +4,4 @@ This file is the single source of truth for the app version.
 CI and build scripts read / inject it automatically.
 """
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"


### PR DESCRIPTION
## Release v0.12.0

Bumps version to `0.12.0` and adds changelog entry.

### What's in this release

**Added**
- Draggable annotations (text, arrow, highlight) in the preview widget

**Changed**
- Larger font sizes across the app for better readability
- Higher-res window thumbnails (800×440) in source picker
- Horizontal keystroke overlay with row wrapping
- Larger background palette swatches

**Fixed**
- Record button icon visibility (white on red)
- Dropdown popup styling (softer, larger items)
- Arrow annotation drag math (midpoint delta)
- Thumbnail fallback size consistency

**Issues closed**: #143, #145, #146, #147, #148, #149, #150